### PR TITLE
This should not be negated. The child drivers are looking for TRUE if it has written and FALSE if it has not. The way it is currently written reverses that.

### DIFF
--- a/libraries/Session.php
+++ b/libraries/Session.php
@@ -427,7 +427,7 @@ class Session extends CI_Driver_Library {
 	 */
 	public function check_write()
 	{
-		return ( ! $this->_has_written );
+		return ( $this->_has_written );
 	}
 
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
Re: https://github.com/danmontgomery/codeigniter-session-driver/commit/6bfedb25485ba8f8f0eb38a40a7b22ba1a6008c6#commitcomment-1249654
